### PR TITLE
Enhancement: Configure no_whitespace_before_comma_in_array to remove whitespace between heredoc and comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,14 @@ For a full diff see [`3a0205c...main`][3a0205c...main].
 * Added `Php80` ([#4]), by [@localheinz]
 * Added `Php71`, `Php72`, `Php73`, and `Php74` ([#1]), by [@localheinz]
 
+### Changed
+
+* Configured `no_whitespace_before_comma_in_array` fixer to remove whitespace between heredoc and comma ([#5]), by [@localheinz]
+
 [3a0205c...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/3a0205c...main
 
 [#1]: https://github.com/hks-systeme/php-cs-fixer-config/pull/1
-[#4]: https://github.com/hks-systeme/php-cs-fixer-config/pull/2
+[#4]: https://github.com/hks-systeme/php-cs-fixer-config/pull/4
+[#5]: https://github.com/hks-systeme/php-cs-fixer-config/pull/5
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -263,7 +263,9 @@ final class Php73 extends AbstractRuleSet
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -263,7 +263,9 @@ final class Php74 extends AbstractRuleSet
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -263,7 +263,9 @@ final class Php80 extends AbstractRuleSet
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -269,7 +269,9 @@ final class Php73Test extends AbstractRuleSetTestCase
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -269,7 +269,9 @@ final class Php74Test extends AbstractRuleSetTestCase
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -269,7 +269,9 @@ final class Php80Test extends AbstractRuleSetTestCase
         'no_useless_else' => true,
         'no_useless_return' => true,
         'no_useless_sprintf' => true,
-        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_before_comma_in_array' => [
+            'after_heredoc' => true,
+        ],
         'no_whitespace_in_blank_line' => true,
         'non_printable_character' => true,
         'normalize_index_brace' => true,


### PR DESCRIPTION
This pull request

* [x] configures the `no_whitespace_before_comma_in_array` to remove whitespace between heredoc and comma 

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.18.1/doc/rules/array_notation/no_whitespace_before_comma_in_array.rst