### PR TITLE
Enhancement: Configure trailing_comma_in_multiline_array to add trailing comma after heredoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,13 @@ For a full diff see [`3a0205c...main`][3a0205c...main].
 ### Changed
 
 * Configured `no_whitespace_before_comma_in_array` fixer to remove whitespace between heredoc and comma ([#5]), by [@localheinz]
+* Configured `trailing_comma_in_multiline_array` fixer to add a trailing comma after heredoc in multi-line array ([#6]), by [@localheinz]
 
 [3a0205c...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/3a0205c...main
 
 [#1]: https://github.com/hks-systeme/php-cs-fixer-config/pull/1
 [#4]: https://github.com/hks-systeme/php-cs-fixer-config/pull/4
 [#5]: https://github.com/hks-systeme/php-cs-fixer-config/pull/5
+[#6]: https://github.com/hks-systeme/php-cs-fixer-config/pull/6
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -533,7 +533,9 @@ final class Php73 extends AbstractRuleSet
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -533,7 +533,9 @@ final class Php74 extends AbstractRuleSet
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -533,7 +533,9 @@ final class Php80 extends AbstractRuleSet
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -539,7 +539,9 @@ final class Php73Test extends AbstractRuleSetTestCase
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -539,7 +539,9 @@ final class Php74Test extends AbstractRuleSetTestCase
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -539,7 +539,9 @@ final class Php80Test extends AbstractRuleSetTestCase
         'ternary_operator_spaces' => true,
         'ternary_to_elvis_operator' => true,
         'ternary_to_null_coalescing' => true,
-        'trailing_comma_in_multiline_array' => true,
+        'trailing_comma_in_multiline_array' => [
+            'after_heredoc' => true,
+        ],
         'trim_array_spaces' => true,
         'unary_operator_spaces' => true,
         'use_arrow_functions' => false,


### PR DESCRIPTION
This pull request

* [x] configures the `trailing_comma_in_multiline_array` fixer to add a trailing comma after heredoc

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v2.18.1/doc/rules/array_notation/trailing_comma_in_multiline_array.rst
