### PR TITLE
Fix: Do not use deprecated configuration for class_attributes_separation fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 For a full diff see [`1.0.0...1.0.0`][1.0.0...main].
 
+### Fixed
+
+* Stopped using deprecated configuration for `class_attributes_separation` fixer ([#15]), by [@localheinz]
+
 ## [`1.0.0`][1.0.0]
 
 For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
@@ -31,5 +35,6 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#4]: https://github.com/hks-systeme/php-cs-fixer-config/pull/4
 [#5]: https://github.com/hks-systeme/php-cs-fixer-config/pull/5
 [#6]: https://github.com/hks-systeme/php-cs-fixer-config/pull/6
+[#15]: https://github.com/hks-systeme/php-cs-fixer-config/pull/15
 
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -68,7 +68,7 @@ final class Php71 extends AbstractRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -68,7 +68,7 @@ final class Php72 extends AbstractRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -68,7 +68,7 @@ final class Php73 extends AbstractRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -68,7 +68,7 @@ final class Php74 extends AbstractRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -68,7 +68,7 @@ final class Php80 extends AbstractRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -74,7 +74,7 @@ final class Php71Test extends AbstractRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -74,7 +74,7 @@ final class Php72Test extends AbstractRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -74,7 +74,7 @@ final class Php73Test extends AbstractRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -74,7 +74,7 @@ final class Php74Test extends AbstractRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -74,7 +74,7 @@ final class Php80Test extends AbstractRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method',
+                'method' => 'one',
             ],
         ],
         'class_definition' => [


### PR DESCRIPTION
This pull request

* [x] stops using the deprecated configuration for the `class_attributes_separation` fixer

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/5485.