### PR TITLE
Fix: Allow mergify to push to main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -36,7 +36,8 @@ branches:
         # Note: User, app, and team restrictions are only available for organization-owned repositories.
         # Set to null to disable when using this configuration for a repository on a personal account.
 
-        apps: []
+        apps:
+          - "mergify"
         teams: []
         users:
           - "hks-systeme-bot"


### PR DESCRIPTION
This pull request

* [x] allows mergify to push to `main`