### PR TITLE
Fix: Do not require previously removed job to pass

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -17,7 +17,6 @@ branches:
           - "Code Coverage (7.2, locked)"
           - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.2, locked)"
-          - "Mutation Tests (7.2, locked)"
           - "Static Code Analysis (7.2, locked)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"


### PR DESCRIPTION
This pull request

* [x] stops requiring a previously removed job to pass

Follows #69.