### PR TITLE
Enhancement: Configure trailing_comma_in_multiline fixer to add trailing commas for arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`1.1.0...main`][1.1.0...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#71]), by [@localheinz]
+* Configured `trailing_comma_in_multiline` fixer to add trailing commas for arguments in `Php73`, `Php74`, and `Php80` rule sets ([#74]), by [@localheinz]
 
 ## [`1.1.0`][1.1.0]
 
@@ -82,6 +83,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#59]: https://github.com/hks-systeme/php-cs-fixer-config/pull/59
 [#67]: https://github.com/hks-systeme/php-cs-fixer-config/pull/67
 [#71]: https://github.com/hks-systeme/php-cs-fixer-config/pull/71
+[#74]: https://github.com/hks-systeme/php-cs-fixer-config/pull/74
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -824,6 +824,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -824,6 +824,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -824,6 +824,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -830,6 +830,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -830,6 +830,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -830,6 +830,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'trailing_comma_in_multiline' => [
             'after_heredoc' => true,
             'elements' => [
+                'arguments',
                 'arrays',
             ],
         ],


### PR DESCRIPTION
This pull request

* [x]  configures the `trailing_comma_in_multiline` fixer to add trailing commas for arguments

Follows #71.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/doc/rules/control_structure/trailing_comma_in_multiline.rst.