### PR TITLE
Enhancement: Configure trailing_comma_in_multiline fixer to add trailing commas for parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`1.1.0...main`][1.1.0...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#71]), by [@localheinz]
 * Configured `trailing_comma_in_multiline` fixer to add trailing commas for arguments in `Php73`, `Php74`, and `Php80` rule sets ([#74]), by [@localheinz]
+* Configured `trailing_comma_in_multiline` fixer to add trailing commas for parameters in `Php80` rule set ([#75]), by [@localheinz]
 
 ## [`1.1.0`][1.1.0]
 
@@ -84,6 +85,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#67]: https://github.com/hks-systeme/php-cs-fixer-config/pull/67
 [#71]: https://github.com/hks-systeme/php-cs-fixer-config/pull/71
 [#74]: https://github.com/hks-systeme/php-cs-fixer-config/pull/74
+[#75]: https://github.com/hks-systeme/php-cs-fixer-config/pull/75
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -826,6 +826,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'elements' => [
                 'arguments',
                 'arrays',
+                'parameters',
             ],
         ],
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -832,6 +832,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'elements' => [
                 'arguments',
                 'arrays',
+                'parameters',
             ],
         ],
         'trim_array_spaces' => true,


### PR DESCRIPTION
This pull request

* [x]  configures the `trailing_comma_in_multiline` fixer to add trailing commas for parameters

Follows #71.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.0/doc/rules/control_structure/trailing_comma_in_multiline.rst.