### PR TITLE
Enhancement: Enable `declare_parentheses` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.0.0...main`][2.0.0...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#121]), by [@dependabot]
+* Enabled `declare_parentheses` fixer ([#125]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -97,6 +98,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#74]: https://github.com/hks-systeme/php-cs-fixer-config/pull/74
 [#75]: https://github.com/hks-systeme/php-cs-fixer-config/pull/75
 [#121]: https://github.com/hks-systeme/php-cs-fixer-config/pull/121
+[#125]: https://github.com/hks-systeme/php-cs-fixer-config/pull/125
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -88,7 +88,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -88,7 +88,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -88,7 +88,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -88,7 +88,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -88,7 +88,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -94,7 +94,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -94,7 +94,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -94,7 +94,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -94,7 +94,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -94,7 +94,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'constant_case' => true,
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
-        'declare_parentheses' => false,
+        'declare_parentheses' => true,
         'declare_strict_types' => true,
         'dir_constant' => true,
         'doctrine_annotation_array_assignment' => [


### PR DESCRIPTION
This pull request

* [x] enables the `declare_parentheses` fixer

Follows #121.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.1.0/doc/rules/language_construct/declare_parentheses.rst.