### PR TITLE
Enhancement: Enable and configure `empty_loop_body` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.0.0...main`][2.0.0...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#121]), by [@dependabot]
 * Enabled `declare_parentheses` fixer ([#125]), by [@localheinz]
+* Enabled and configured `empty_loop_body` fixer ([#126]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -99,6 +100,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#75]: https://github.com/hks-systeme/php-cs-fixer-config/pull/75
 [#121]: https://github.com/hks-systeme/php-cs-fixer-config/pull/121
 [#125]: https://github.com/hks-systeme/php-cs-fixer-config/pull/125
+[#126]: https://github.com/hks-systeme/php-cs-fixer-config/pull/126
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -117,7 +117,9 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -117,7 +117,9 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -117,7 +117,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -117,7 +117,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -117,7 +117,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -123,7 +123,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -123,7 +123,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -123,7 +123,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -123,7 +123,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -123,7 +123,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'shorten_simple_statements_only' => true,
         ],
         'elseif' => true,
-        'empty_loop_body' => false,
+        'empty_loop_body' => [
+            'style' => 'braces',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,


### PR DESCRIPTION
This pull request

* [x] enables and configures the `empty_loop_body` fixer

Follows #121.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.1.0/doc/rules/control_structure/empty_loop_body.rst.