### PR TITLE
Enhancement: Configure `class_attributes_separation` fixer to use `only_if_meta` option for elements `const` and `property`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`2.0.0...main`][2.0.0...main].
 * Enabled `declare_parentheses` fixer ([#125]), by [@localheinz]
 * Enabled and configured `empty_loop_body` fixer ([#126]), by [@localheinz]
 * Enabled and configured `types_spaces` fixer ([#127]), by [@localheinz]
+* Configured `class_attributes_separation` fixer to use newly added `only_if_meta` option for elements `const` and `property` ([#128]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -103,6 +104,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#125]: https://github.com/hks-systeme/php-cs-fixer-config/pull/125
 [#126]: https://github.com/hks-systeme/php-cs-fixer-config/pull/126
 [#127]: https://github.com/hks-systeme/php-cs-fixer-config/pull/127
+[#128]: https://github.com/hks-systeme/php-cs-fixer-config/pull/128
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -67,7 +67,9 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -16,7 +16,6 @@ namespace HKS\PhpCsFixer\Config\RuleSet;
 final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'hks (PHP 7.1)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -575,6 +574,5 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70100;
 }

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -16,7 +16,6 @@ namespace HKS\PhpCsFixer\Config\RuleSet;
 final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'hks (PHP 7.2)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -575,6 +574,5 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70200;
 }

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -67,7 +67,9 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -16,7 +16,6 @@ namespace HKS\PhpCsFixer\Config\RuleSet;
 final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'hks (PHP 7.3)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -578,6 +577,5 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70300;
 }

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -67,7 +67,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -67,7 +67,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -16,7 +16,6 @@ namespace HKS\PhpCsFixer\Config\RuleSet;
 final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'hks (PHP 7.4)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -578,6 +577,5 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70400;
 }

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -67,7 +67,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -16,7 +16,6 @@ namespace HKS\PhpCsFixer\Config\RuleSet;
 final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
 {
     protected $name = 'hks (PHP 8.0)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -579,6 +578,5 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 80000;
 }

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -22,7 +22,6 @@ namespace HKS\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php71Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'hks (PHP 7.1)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -581,6 +580,5 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70100;
 }

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -73,7 +73,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -73,7 +73,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -22,7 +22,6 @@ namespace HKS\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php72Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'hks (PHP 7.2)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -581,6 +580,5 @@ final class Php72Test extends ExplicitRuleSetTestCase
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70200;
 }

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -22,7 +22,6 @@ namespace HKS\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php73Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'hks (PHP 7.3)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -584,6 +583,5 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70300;
 }

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -73,7 +73,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -22,7 +22,6 @@ namespace HKS\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php74Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'hks (PHP 7.4)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -584,6 +583,5 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 70400;
 }

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -73,7 +73,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -73,7 +73,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'cast_spaces' => true,
         'class_attributes_separation' => [
             'elements' => [
+                'const' => 'only_if_meta',
                 'method' => 'one',
+                'property' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -22,7 +22,6 @@ namespace HKS\PhpCsFixer\Config\Test\Unit\RuleSet;
 final class Php80Test extends ExplicitRuleSetTestCase
 {
     protected $name = 'hks (PHP 8.0)';
-
     protected $rules = [
         'align_multiline_comment' => [
             'comment_type' => 'all_multiline',
@@ -585,6 +584,5 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'whitespace_after_comma_in_array' => true,
         'yoda_style' => false,
     ];
-
     protected $targetPhpVersion = 80000;
 }


### PR DESCRIPTION
This pull request

* [x] configures the `class_attributes_separation` fixer to use the newly added `only_if_meta` option for elements `const` and `property`
* [ ] runs `make coding-standards`

Follows #121.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.1/doc/rules/class_notation/class_attributes_separation.rst.