### PR TITLE
Enhancement: Configure `class_attributes_separation` fixer to use `none` option for element `trait_import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`2.0.0...main`][2.0.0...main].
 * Enabled and configured `empty_loop_body` fixer ([#126]), by [@localheinz]
 * Enabled and configured `types_spaces` fixer ([#127]), by [@localheinz]
 * Configured `class_attributes_separation` fixer to use newly added `only_if_meta` option for elements `const` and `property` ([#128]), by [@localheinz]
+* Configured `class_attributes_separation` fixer to use `none` option for element `trait_import` ([#129]), by [@localheinz]
 
 ## [`2.0.0`][2.0.0]
 
@@ -105,6 +106,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#126]: https://github.com/hks-systeme/php-cs-fixer-config/pull/126
 [#127]: https://github.com/hks-systeme/php-cs-fixer-config/pull/127
 [#128]: https://github.com/hks-systeme/php-cs-fixer-config/pull/128
+[#129]: https://github.com/hks-systeme/php-cs-fixer-config/pull/129
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -69,6 +69,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -69,6 +69,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -69,6 +69,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -69,6 +69,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -69,6 +69,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -75,6 +75,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -75,6 +75,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -75,6 +75,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -75,6 +75,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -75,6 +75,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
+                'trait_import' => 'none',
             ],
         ],
         'class_definition' => [


### PR DESCRIPTION
This pull request

* [x] configures the `class_attributes_separation` fixer to use the `none` option for element `trait_import`

Follows #121.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.1/doc/rules/class_notation/class_attributes_separation.rst.