### PR TITLE
Enhancement: Configure `class_attributes_separation` fixer to use `only_if_meta` option for `trait_import` element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.1.0...main`][2.1.0...main].
+For a full diff see [`2.2.0...main`][2.2.0...main].
+
+## [`2.2.0`][2.2.0]
+
+For a full diff see [`2.1.0...2.2.0`][2.1.0...2.2.0].
+
+### Changed
+
+* Configured `class_attributes_separation` fixer to use `only_if_meta` option for element `trait_import` ([#132]), by [@localheinz]
 
 ## [`2.1.0`][2.1.0]
 
@@ -87,6 +95,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [1.1.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/1.1.0
 [2.0.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.0.0
 [2.1.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.1.0
+[2.2.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.1.0
 
 [3a0205c...1.0.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/3a0205c...1.0.0
 [1.0.0...1.0.1]: https://github.com/hks-systeme/php-cs-fixer-config/compare/1.0.0...1.0.1
@@ -95,7 +104,8 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [1.0.3...1.1.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/1.0.3...1.1.0
 [1.1.0...2.0.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/1.1.0...2.0.0
 [2.0.0...2.1.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.0.0...2.1.0
-[2.1.0...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.1.0...main
+[2.1.0...2.2.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.1.0...2.2.0
+[2.2.0...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.2.0...main
 
 [#1]: https://github.com/hks-systeme/php-cs-fixer-config/pull/1
 [#4]: https://github.com/hks-systeme/php-cs-fixer-config/pull/4
@@ -117,6 +127,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#129]: https://github.com/hks-systeme/php-cs-fixer-config/pull/129
 [#130]: https://github.com/hks-systeme/php-cs-fixer-config/pull/130
 [#131]: https://github.com/hks-systeme/php-cs-fixer-config/pull/131
+[#132]: https://github.com/hks-systeme/php-cs-fixer-config/pull/132
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -69,7 +69,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -69,7 +69,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -69,7 +69,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -69,7 +69,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -69,7 +69,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -75,7 +75,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -75,7 +75,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -75,7 +75,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -75,7 +75,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -75,7 +75,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'const' => 'only_if_meta',
                 'method' => 'one',
                 'property' => 'only_if_meta',
-                'trait_import' => 'none',
+                'trait_import' => 'only_if_meta',
             ],
         ],
         'class_definition' => [


### PR DESCRIPTION
This pull request

* [x] configures the `class_attributes_separation` fixer to use the `only_if_meta` option for element `trait_import`

Follows #121.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.0.1/doc/rules/class_notation/class_attributes_separation.rst.