### PR TITLE
Fix: Stop using deprecated `use_trait` option for `no_extra_blank_lines` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#138]), by [@dependabot]
 
+### Fixed
+
+* Stopped using deprecated `use_trait` option for `no_extra_blank_lines` fixer ([#139]), by [@localheinz]
+
 ## [`2.2.0`][2.2.0]
 
 For a full diff see [`2.1.0...2.2.0`][2.1.0...2.2.0].
@@ -133,6 +137,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#131]: https://github.com/hks-systeme/php-cs-fixer-config/pull/131
 [#132]: https://github.com/hks-systeme/php-cs-fixer-config/pull/132
 [#138]: https://github.com/hks-systeme/php-cs-fixer-config/pull/138
+[#139]: https://github.com/hks-systeme/php-cs-fixer-config/pull/139
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -248,7 +248,6 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -248,7 +248,6 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -248,7 +248,6 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -248,7 +248,6 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -248,7 +248,6 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -254,7 +254,6 @@ final class Php71Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -254,7 +254,6 @@ final class Php72Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -254,7 +254,6 @@ final class Php73Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -254,7 +254,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -254,7 +254,6 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'switch',
                 'throw',
                 'use',
-                'use_trait',
             ],
         ],
         'no_homoglyph_names' => true,


### PR DESCRIPTION
This pull request

* [x] stop using the deprecated `use_trait` option for the `no_extra_blank_lines` fixer

Follows #138.