### PR TITLE
Enhancement: Enable `assign_null_coalescing_to_coalesce_equal` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#138]), by [@dependabot]
+* Enabled `assign_null_coalescing_to_coalesce_equal` fixer in `Php74` and `Php80` rule sets ([#140]), by [@localheinz]
 
 ### Fixed
 
@@ -138,6 +139,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#132]: https://github.com/hks-systeme/php-cs-fixer-config/pull/132
 [#138]: https://github.com/hks-systeme/php-cs-fixer-config/pull/138
 [#139]: https://github.com/hks-systeme/php-cs-fixer-config/pull/139
+[#140]: https://github.com/hks-systeme/php-cs-fixer-config/pull/140
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -25,7 +25,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'assign_null_coalescing_to_coalesce_equal' => false,
+        'assign_null_coalescing_to_coalesce_equal' => true,
         'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -25,7 +25,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'assign_null_coalescing_to_coalesce_equal' => false,
+        'assign_null_coalescing_to_coalesce_equal' => true,
         'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -31,7 +31,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'assign_null_coalescing_to_coalesce_equal' => false,
+        'assign_null_coalescing_to_coalesce_equal' => true,
         'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -31,7 +31,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'array_syntax' => [
             'syntax' => 'short',
         ],
-        'assign_null_coalescing_to_coalesce_equal' => false,
+        'assign_null_coalescing_to_coalesce_equal' => true,
         'backtick_to_shell_exec' => true,
         'binary_operator_spaces' => [
             'default' => 'single_space',


### PR DESCRIPTION
This pull request

* [x] enables the `assign_null_coalescing_to_coalesce_equal` fixer

Follows #138.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/operator/assign_null_coalescing_to_coalesce_equal.rst.