### PR TITLE
Enhancement: Enable and configure `control_structure_continuation_position` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 
 * Updated `friendsofphp/php-cs-fixer` ([#138]), by [@dependabot]
 * Enabled `assign_null_coalescing_to_coalesce_equal` fixer in `Php74` and `Php80` rule sets ([#140]), by [@localheinz]
+* Enabled and configured `control_structure_continuation_position` fixer ([#141]), by [@localheinz]
 
 ### Fixed
 
@@ -140,6 +141,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#138]: https://github.com/hks-systeme/php-cs-fixer-config/pull/138
 [#139]: https://github.com/hks-systeme/php-cs-fixer-config/pull/139
 [#140]: https://github.com/hks-systeme/php-cs-fixer-config/pull/140
+[#141]: https://github.com/hks-systeme/php-cs-fixer-config/pull/140
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -89,7 +89,9 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -89,7 +89,9 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -89,7 +89,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -89,7 +89,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -89,7 +89,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -95,7 +95,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -95,7 +95,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -95,7 +95,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -95,7 +95,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -95,7 +95,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'spacing' => 'one',
         ],
         'constant_case' => true,
-        'control_structure_continuation_position' => false,
+        'control_structure_continuation_position' => [
+            'position' => 'same_line',
+        ],
         'date_time_immutable' => false,
         'declare_equal_normalize' => true,
         'declare_parentheses' => true,


### PR DESCRIPTION
This pull request

* [x] enables and configures the `control_structure_continuation_position` fixer

Follows #138.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/control_structure/control_structure_continuation_position.rst.
