### PR TITLE
Enhancement: Enable and configure `empty_loop_condition` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 * Updated `friendsofphp/php-cs-fixer` ([#138]), by [@dependabot]
 * Enabled `assign_null_coalescing_to_coalesce_equal` fixer in `Php74` and `Php80` rule sets ([#140]), by [@localheinz]
 * Enabled and configured `control_structure_continuation_position` fixer ([#141]), by [@localheinz]
+* Enabled and configured `empty_loop_condition` fixer ([#142]), by [@localheinz]
 
 ### Fixed
 
@@ -142,6 +143,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#139]: https://github.com/hks-systeme/php-cs-fixer-config/pull/139
 [#140]: https://github.com/hks-systeme/php-cs-fixer-config/pull/140
 [#141]: https://github.com/hks-systeme/php-cs-fixer-config/pull/141
+[#142]: https://github.com/hks-systeme/php-cs-fixer-config/pull/142
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -126,7 +126,9 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -126,7 +126,9 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -126,7 +126,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -126,7 +126,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -126,7 +126,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -132,7 +132,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -132,7 +132,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -132,7 +132,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -132,7 +132,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -132,7 +132,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'empty_loop_body' => [
             'style' => 'braces',
         ],
-        'empty_loop_condition' => false,
+        'empty_loop_condition' => [
+            'style' => 'while',
+        ],
         'encoding' => true,
         'ereg_to_preg' => true,
         'error_suppression' => true,


### PR DESCRIPTION
This pull request

* [x] enables and configures the `empty_loop_condition` fixer

Follows #138.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/control_structure/empty_loop_condition.rst.