### PR TITLE
Enhancement: Enable `integer_literal_case` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 * Enabled `assign_null_coalescing_to_coalesce_equal` fixer in `Php74` and `Php80` rule sets ([#140]), by [@localheinz]
 * Enabled and configured `control_structure_continuation_position` fixer ([#141]), by [@localheinz]
 * Enabled and configured `empty_loop_condition` fixer ([#142]), by [@localheinz]
+* Enabled `integer_literal_case` fixer ([#143]), by [@localheinz]
 
 ### Fixed
 
@@ -144,6 +145,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#140]: https://github.com/hks-systeme/php-cs-fixer-config/pull/140
 [#141]: https://github.com/hks-systeme/php-cs-fixer-config/pull/141
 [#142]: https://github.com/hks-systeme/php-cs-fixer-config/pull/142
+[#143]: https://github.com/hks-systeme/php-cs-fixer-config/pull/143
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -177,7 +177,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -177,7 +177,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -177,7 +177,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -177,7 +177,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -177,7 +177,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -183,7 +183,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -183,7 +183,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -183,7 +183,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -183,7 +183,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -183,7 +183,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'style' => 'pre',
         ],
         'indentation_type' => true,
-        'integer_literal_case' => false,
+        'integer_literal_case' => true,
         'is_null' => true,
         'lambda_not_used_import' => true,
         'line_ending' => true,


### PR DESCRIPTION
This pull request

* [x] enables the `integer_literal_case` fixer

Follows #138.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/casing/integer_literal_case.rst.