### PR TITLE
Enhancement: Enable `modernize_strpos` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 * Enabled and configured `control_structure_continuation_position` fixer ([#141]), by [@localheinz]
 * Enabled and configured `empty_loop_condition` fixer ([#142]), by [@localheinz]
 * Enabled `integer_literal_case` fixer ([#143]), by [@localheinz]
+* Enabled `modernize_strpos` fixer for `Php80` rule set ([#144]), by [@localheinz]
 
 ### Fixed
 
@@ -146,6 +147,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#141]: https://github.com/hks-systeme/php-cs-fixer-config/pull/141
 [#142]: https://github.com/hks-systeme/php-cs-fixer-config/pull/142
 [#143]: https://github.com/hks-systeme/php-cs-fixer-config/pull/143
+[#144]: https://github.com/hks-systeme/php-cs-fixer-config/pull/144
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -198,7 +198,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_strpos' => false,
+        'modernize_strpos' => true,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -204,7 +204,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'on_multiline' => 'ensure_fully_multiline',
         ],
         'method_chaining_indentation' => true,
-        'modernize_strpos' => false,
+        'modernize_strpos' => true,
         'modernize_types_casting' => true,
         'multiline_comment_opening_closing' => true,
         'multiline_whitespace_before_semicolons' => [


### PR DESCRIPTION
This pull request

* [x] enables the `modernize_strpos` fixer

Follows #138.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/alias/modernize_strpos.rst.