### PR TITLE
Enhancement: Enable `no_space_around_double_colon` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 * Enabled and configured `empty_loop_condition` fixer ([#142]), by [@localheinz]
 * Enabled `integer_literal_case` fixer ([#143]), by [@localheinz]
 * Enabled `modernize_strpos` fixer for `Php80` rule set ([#144]), by [@localheinz]
+* Enabled `no_space_around_double_colon` fixer ([#145]), by [@localheinz]
 
 ### Fixed
 
@@ -148,6 +149,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#142]: https://github.com/hks-systeme/php-cs-fixer-config/pull/142
 [#143]: https://github.com/hks-systeme/php-cs-fixer-config/pull/143
 [#144]: https://github.com/hks-systeme/php-cs-fixer-config/pull/144
+[#145]: https://github.com/hks-systeme/php-cs-fixer-config/pull/145
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -265,7 +265,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -265,7 +265,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -265,7 +265,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -265,7 +265,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -265,7 +265,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -271,7 +271,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -271,7 +271,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -271,7 +271,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -271,7 +271,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -271,7 +271,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'no_php4_constructor' => false,
         'no_short_bool_cast' => true,
         'no_singleline_whitespace_before_semicolons' => true,
-        'no_space_around_double_colon' => false,
+        'no_space_around_double_colon' => true,
         'no_spaces_after_function_name' => true,
         'no_spaces_around_offset' => true,
         'no_spaces_inside_parenthesis' => true,


### PR DESCRIPTION
This pull request

* [x] enables the `no_space_around_double_colon` fixer

Follows #138.

💁‍♂️ For reference, https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/operator/no_space_around_double_colon.rst.