### PR TITLE
Enhancement: Enable `string_length_to_empty` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 * Enabled `integer_literal_case` fixer ([#143]), by [@localheinz]
 * Enabled `modernize_strpos` fixer for `Php80` rule set ([#144]), by [@localheinz]
 * Enabled `no_space_around_double_colon` fixer ([#145]), by [@localheinz]
+* Enabled `string_length_to_empty` fixer ([#146]), by [@localheinz]
 
 ### Fixed
 
@@ -150,6 +151,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#143]: https://github.com/hks-systeme/php-cs-fixer-config/pull/143
 [#144]: https://github.com/hks-systeme/php-cs-fixer-config/pull/144
 [#145]: https://github.com/hks-systeme/php-cs-fixer-config/pull/145
+[#146]: https://github.com/hks-systeme/php-cs-fixer-config/pull/146
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -559,7 +559,7 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -559,7 +559,7 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -561,7 +561,7 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -561,7 +561,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -561,7 +561,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -565,7 +565,7 @@ final class Php71Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -565,7 +565,7 @@ final class Php72Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -567,7 +567,7 @@ final class Php73Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -567,7 +567,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -567,7 +567,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
         'static_lambda' => true,
         'strict_comparison' => false,
         'strict_param' => false,
-        'string_length_to_empty' => false,
+        'string_length_to_empty' => true,
         'string_line_ending' => true,
         'switch_case_semicolon_to_colon' => true,
         'switch_case_space' => true,


### PR DESCRIPTION
This pull request

* [x] enables the `string_length_to_empty` fixer

Follows #138.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.2.1/doc/rules/string_notation/string_length_to_empty.rst.