### PR TITLE
Fix: Explicitly configure `cast_spaces` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ For a full diff see [`2.2.0...main`][2.2.0...main].
 ### Fixed
 
 * Stopped using deprecated `use_trait` option for `no_extra_blank_lines` fixer ([#139]), by [@localheinz]
+* Explicitly configured `cast_spaces` fixer ([#147]), by [@localheinz]
 
 ## [`2.2.0`][2.2.0]
 
@@ -152,6 +153,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#144]: https://github.com/hks-systeme/php-cs-fixer-config/pull/144
 [#145]: https://github.com/hks-systeme/php-cs-fixer-config/pull/145
 [#146]: https://github.com/hks-systeme/php-cs-fixer-config/pull/146
+[#147]: https://github.com/hks-systeme/php-cs-fixer-config/pull/147
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php71.php
+++ b/src/RuleSet/Php71.php
@@ -64,7 +64,9 @@ final class Php71 extends AbstractRuleSet implements ExplicitRuleSet
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/src/RuleSet/Php72.php
+++ b/src/RuleSet/Php72.php
@@ -64,7 +64,9 @@ final class Php72 extends AbstractRuleSet implements ExplicitRuleSet
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/src/RuleSet/Php73.php
+++ b/src/RuleSet/Php73.php
@@ -64,7 +64,9 @@ final class Php73 extends AbstractRuleSet implements ExplicitRuleSet
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -64,7 +64,9 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -64,7 +64,9 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php71Test.php
+++ b/test/Unit/RuleSet/Php71Test.php
@@ -70,7 +70,9 @@ final class Php71Test extends ExplicitRuleSetTestCase
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php72Test.php
+++ b/test/Unit/RuleSet/Php72Test.php
@@ -70,7 +70,9 @@ final class Php72Test extends ExplicitRuleSetTestCase
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php73Test.php
+++ b/test/Unit/RuleSet/Php73Test.php
@@ -70,7 +70,9 @@ final class Php73Test extends ExplicitRuleSetTestCase
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -70,7 +70,9 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -70,7 +70,9 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'position_after_control_structures' => 'same',
             'position_after_functions_and_oop_constructs' => 'next',
         ],
-        'cast_spaces' => true,
+        'cast_spaces' => [
+            'space' => 'single',
+        ],
         'class_attributes_separation' => [
             'elements' => [
                 'const' => 'only_if_meta',


### PR DESCRIPTION
This pull request

* [x] explicitly configures the `cast_spaces` fixer