### PR TITLE
Fix: Stop using `parameters` option for `trailing_comma_in_multiline` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.3.0...main`][2.3.0...main].
+For a full diff see [`2.3.1...main`][2.3.1...main].
+
+## [`2.3.1`][2.3.1]
+
+For a full diff see [`2.3.0...2.3.1`][2.3.0...2.3.1].
 
 ### Changed
 
 * Updated `friendsofphp/php-cs-fixer` ([#149]), by [@dependabot]
+
+### Fixed
+
+* Stopped using `parameters` option for `trailing_comma_in_multiline` fixer in `Php74` rule set ([#150]), by [@localheinz]
 
 ## [`2.3.0`][2.3.0]
 
@@ -122,6 +130,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [2.1.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.1.0
 [2.2.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.2.0
 [2.3.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.3.0
+[2.3.1]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.3.1
 
 [3a0205c...1.0.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/3a0205c...1.0.0
 [1.0.0...1.0.1]: https://github.com/hks-systeme/php-cs-fixer-config/compare/1.0.0...1.0.1
@@ -132,7 +141,8 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [2.0.0...2.1.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.0.0...2.1.0
 [2.1.0...2.2.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.1.0...2.2.0
 [2.2.0...2.3.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.2.0...2.3.0
-[2.3.0...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.3.0...main
+[2.3.0...2.3.1]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.3.0...2.3.1
+[2.3.1...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.3.1...main
 
 [#1]: https://github.com/hks-systeme/php-cs-fixer-config/pull/1
 [#4]: https://github.com/hks-systeme/php-cs-fixer-config/pull/4
@@ -167,6 +177,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#147]: https://github.com/hks-systeme/php-cs-fixer-config/pull/147
 [#148]: https://github.com/hks-systeme/php-cs-fixer-config/pull/148
 [#149]: https://github.com/hks-systeme/php-cs-fixer-config/pull/149
+[#150]: https://github.com/hks-systeme/php-cs-fixer-config/pull/150
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -578,7 +578,6 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'elements' => [
                 'arguments',
                 'arrays',
-                'parameters',
             ],
         ],
         'trim_array_spaces' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -584,7 +584,6 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'elements' => [
                 'arguments',
                 'arrays',
-                'parameters',
             ],
         ],
         'trim_array_spaces' => true,


### PR DESCRIPTION
This pull request

* [x] stops using the `parameters` option for the `trailing_comma_in_multiline` fixer

Follows #138.