### PR TITLE
Enhancement: Enable `get_class_to_class_keyword` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For a full diff see [`2.7.0...main`][2.7.0...main].
 
 ### Changed
 
+- Enabled `get_class_to_class_keyword` fixer ([#204]), by [@localheinz]
 - Updated `friendsofphp/php-cs-fixer` ([#202]), by [@dependabot]
 
 ## [`2.7.0`][2.7.0]
@@ -239,6 +240,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#193]: https://github.com/hks-systeme/php-cs-fixer-config/pull/193
 [#196]: https://github.com/hks-systeme/php-cs-fixer-config/pull/196
 [#202]: https://github.com/hks-systeme/php-cs-fixer-config/pull/202
+[#204]: https://github.com/hks-systeme/php-cs-fixer-config/pull/204
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -170,7 +170,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -170,7 +170,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -176,7 +176,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -176,7 +176,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
                 'inheritdocs' => 'inheritdoc',
             ],
         ],
-        'get_class_to_class_keyword' => false,
+        'get_class_to_class_keyword' => true,
         'global_namespace_import' => false,
         'group_import' => false,
         'header_comment' => false,


### PR DESCRIPTION
This pull request

- [x] enables the `get_class_to_class_keyword` fixer

Follows #202.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.5.0/doc/rules/language_construct/get_class_to_class_keyword.rst.