### PR TITLE
Enhancement: Enable `class_reference_name_casing` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For a full diff see [`2.8.0...main`][2.8.0...main].
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#218]), by [@dependabot]
+- Enabled `class_reference_name_casing` fixer ([#219]), by [@localheinz]
 
 ## [`2.8.0`][2.8.0]
 
@@ -252,6 +253,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#202]: https://github.com/hks-systeme/php-cs-fixer-config/pull/202
 [#204]: https://github.com/hks-systeme/php-cs-fixer-config/pull/204
 [#218]: https://github.com/hks-systeme/php-cs-fixer-config/pull/218
+[#219]: https://github.com/hks-systeme/php-cs-fixer-config/pull/219
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -81,7 +81,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'single_line' => true,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -81,7 +81,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'single_line' => true,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -81,7 +81,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'single_line' => true,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -87,7 +87,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'single_line' => true,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -87,7 +87,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'single_line' => true,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -87,7 +87,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'single_line' => true,
             'space_before_parenthesis' => false,
         ],
-        'class_reference_name_casing' => false,
+        'class_reference_name_casing' => true,
         'clean_namespace' => true,
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,


### PR DESCRIPTION
This pull request

- [x] enables the `class_reference_name_casing` fixer

Follows #218.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.6.0/doc/rules/casing/class_reference_name_casing.rst.
