### PR TITLE
Enhancement: Enable `no_unneeded_import_alias` fixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.8.0...main`][2.8.0...main].
+For a full diff see [`2.9.0...main`][2.9.0...main].
+
+## [`2.9.0`][2.9.0]
+
+For a full diff see [`2.8.0...2.9.0`][2.8.0...2.9.0].
 
 ### Changed
 
 - Updated `friendsofphp/php-cs-fixer` ([#218]), by [@dependabot]
 - Enabled `class_reference_name_casing` fixer ([#219]), by [@localheinz]
+- Enabled `no_unneeded_import_alias` fixer ([#220]), by [@localheinz]
 
 ## [`2.8.0`][2.8.0]
 
@@ -189,7 +194,8 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [2.5.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.5.0
 [2.6.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.6.0
 [2.7.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.7.0
-[2.9.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.8.0
+[2.8.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.8.0
+[2.9.0]: https://github.com/hks-systeme/php-cs-fixer-config/releases/tag/2.9.0
 
 [3a0205c...1.0.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/3a0205c...1.0.0
 [1.0.0...1.0.1]: https://github.com/hks-systeme/php-cs-fixer-config/compare/1.0.0...1.0.1
@@ -206,7 +212,8 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [2.5.0...2.6.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.5.0...2.6.0
 [2.6.0...2.7.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.6.0...2.7.0
 [2.7.0...2.8.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.7.0...2.8.0
-[2.8.0...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.8.0...main
+[2.8.0...2.9.0]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.8.0...2.9.0
+[2.9.0...main]: https://github.com/hks-systeme/php-cs-fixer-config/compare/2.9.0...main
 
 [#1]: https://github.com/hks-systeme/php-cs-fixer-config/pull/1
 [#4]: https://github.com/hks-systeme/php-cs-fixer-config/pull/4
@@ -254,6 +261,7 @@ For a full diff see [`3a0205c...1.0.0`][3a0205c...1.0.0].
 [#204]: https://github.com/hks-systeme/php-cs-fixer-config/pull/204
 [#218]: https://github.com/hks-systeme/php-cs-fixer-config/pull/218
 [#219]: https://github.com/hks-systeme/php-cs-fixer-config/pull/219
+[#220]: https://github.com/hks-systeme/php-cs-fixer-config/pull/220
 
 [@dependabot]: https://github.com/apps/dependabot
 [@localheinz]: https://github.com/localheinz

--- a/src/RuleSet/Php74.php
+++ b/src/RuleSet/Php74.php
@@ -291,7 +291,7 @@ final class Php74 extends AbstractRuleSet implements ExplicitRuleSet
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/src/RuleSet/Php80.php
+++ b/src/RuleSet/Php80.php
@@ -291,7 +291,7 @@ final class Php80 extends AbstractRuleSet implements ExplicitRuleSet
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/src/RuleSet/Php81.php
+++ b/src/RuleSet/Php81.php
@@ -291,7 +291,7 @@ final class Php81 extends AbstractRuleSet implements ExplicitRuleSet
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/test/Unit/RuleSet/Php74Test.php
+++ b/test/Unit/RuleSet/Php74Test.php
@@ -297,7 +297,7 @@ final class Php74Test extends ExplicitRuleSetTestCase
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/test/Unit/RuleSet/Php80Test.php
+++ b/test/Unit/RuleSet/Php80Test.php
@@ -297,7 +297,7 @@ final class Php80Test extends ExplicitRuleSetTestCase
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,

--- a/test/Unit/RuleSet/Php81Test.php
+++ b/test/Unit/RuleSet/Php81Test.php
@@ -297,7 +297,7 @@ final class Php81Test extends ExplicitRuleSetTestCase
             'namespaces' => true,
         ],
         'no_unneeded_final_method' => true,
-        'no_unneeded_import_alias' => false,
+        'no_unneeded_import_alias' => true,
         'no_unreachable_default_argument_value' => true,
         'no_unset_cast' => true,
         'no_unset_on_property' => false,


### PR DESCRIPTION
This pull request

- [x] enables the `no_unneeded_import_alias` fixer

Follows #218.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/v3.6.0/doc/rules/import/no_unneeded_import_alias.rst.